### PR TITLE
Clarify source request guidance and add example implementations to contributing docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/SOURCE-REQUEST.yml
+++ b/.github/ISSUE_TEMPLATE/SOURCE-REQUEST.yml
@@ -7,6 +7,12 @@ body:
     attributes:
       value: |
         Thanks for taking the time to fill out this source request!
+
+        Source requests are very welcome. Please note that only a small number of contributors are currently active in implementing new requests. Most available maintainer capacity is currently focused on reviewing pull requests and fixing critical issues.
+
+        If you already have enough information for your municipality/region, you are very welcome to implement the source and open a pull request yourself: [How to contribute](https://github.com/mampfes/hacs_waste_collection_schedule/blob/master/doc/contributing.md).
+
+        If you can support implementation, testing, documentation, or reviews, the project would greatly appreciate your help.
   - type: input
     id: region
     attributes:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Waste collection schedules in the following formats and countries are supported.
 
 If your service provider is not listed, feel free to open a [source request issue](https://github.com/mampfes/hacs_waste_collection_schedule/issues/new?assignees=&labels=source+request&projects=&template=SOURCE-REQUEST.yml&title=%5BSource+Request%5D%3A+) (please first check the [Issues section](https://github.com/mampfes/hacs_waste_collection_schedule/issues) if there already is an open issue for your service provider.).
 
+Source requests are always welcome. At the moment, however, only a small number of contributors are actively implementing new requests, while the available maintainers are mainly busy reviewing pull requests and fixing critical issues.
+
+If you already have enough information for your municipality/region, you are very welcome to implement the source and open a pull request yourself. A step-by-step guide is available in [How to contribute](/doc/contributing.md). Community help with implementation, testing, documentation, and reviews is greatly appreciated.
+
 <details>
 <summary>ICS/iCal and User-Specified</summary>
 

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -57,6 +57,14 @@ There are 2 ways to add support for a new service provider:
 
    This is the fallback if the preferred way via the generic ICS source doesn't work.
 
+### Example Implementations
+
+If you want to contribute a new source, these existing implementations can be used as practical examples:
+
+- **HTML parsing (BeautifulSoup / bs4):** [`birmingham_gov_uk.py`](/custom_components/waste_collection_schedule/waste_collection_schedule/source/birmingham_gov_uk.py)
+- **ICS-based implementation:** [`stadtreinigung_hamburg.py`](/custom_components/waste_collection_schedule/waste_collection_schedule/source/stadtreinigung_hamburg.py)
+- **JSON/API implementation:** [`toronto_ca.py`](/custom_components/waste_collection_schedule/waste_collection_schedule/source/toronto_ca.py)
+
 ### Sync Branch and Create A Pull Request
 
 Having completed your changes, sync your local branch to your GitHub repo, and then create a pull request. When creating a pull request, please provide a meaningful description of what the pull request covers. Ideally it should cite the service provider, confirm the .py, .md, README and info.md files have all been updated, and the output of the test_sources.py script demonstrating functionality. Once submitted a number of automated tests are run against the updated files to confirm they can be merged into the master branch. Note: Pull requests from first time contributors also undergo a manual code review before a merge confirmation in indicated.


### PR DESCRIPTION
### Motivation

- Make it clearer to users that source requests are welcome but maintainer capacity for implementing new sources is limited.
- Encourage community contributions by linking to contribution guidance and providing concrete example implementations to follow.

### Description

- Expand the `SOURCE-REQUEST` issue template with guidance about current maintainer capacity and a link to `doc/contributing.md` and an invitation to help with implementation, testing, documentation, or reviews.  
- Add a similar contributor note to `README.md` explaining that source requests are welcome and linking to `doc/contributing.md`.  
- Add an `Example Implementations` section to `doc/contributing.md` listing concrete example source implementations (`birmingham_gov_uk.py`, `stadtreinigung_hamburg.py`, `toronto_ca.py`) and their implementation types (HTML parsing, ICS, JSON/API). 

### Testing

- Executed the repository's automated CI checks (linting and test suite) on the updated documentation and templates and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a87e3fb36083288b96719a175cac97)