### PR TITLE
Fix Abfall Neunkirchen Siegerland source with Cloudflare bypass

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_neunkirchen_siegerland_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_neunkirchen_siegerland_de.py
@@ -1,4 +1,4 @@
-import requests
+from curl_cffi import requests
 from waste_collection_schedule import Collection, Icons  # type: ignore[attr-defined]
 from waste_collection_schedule.exceptions import (
     SourceArgAmbiguousWithSuggestions,
@@ -7,9 +7,11 @@ from waste_collection_schedule.exceptions import (
 from waste_collection_schedule.service.ICS import ICS
 
 TITLE = "Neunkirchen Siegerland"
-DESCRIPTION = " Source for 'Abfallkalender Neunkirchen Siegerland'."
+DESCRIPTION = "Source for 'Abfallkalender Neunkirchen Siegerland'."
 URL = "https://www.neunkirchen-siegerland.de"
+COUNTRY = "de"
 TEST_CASES = {"Waldstraße": {"strasse": "Waldstr"}}
+SOURCE_CODEOWNERS = ["@bbr111"]
 
 ICON_MAP = {
     "Biotonne": Icons.BIO_KITCHEN,
@@ -22,11 +24,15 @@ ICON_MAP = {
     "Schadstoffsammlung": Icons.HAZARDOUS,
 }
 
+PARAM_TRANSLATIONS: dict = {}
+PARAM_DESCRIPTIONS: dict = {}
+
 
 class Source:
     def __init__(self, strasse):
         self._strasse = strasse
         self._ics = ICS()
+        self._session = requests.Session(impersonate="chrome")
 
     def fetch(self):
         args = {
@@ -37,7 +43,7 @@ class Source:
             "term": self._strasse,
         }
         header = {"Referer": URL}
-        r = requests.get(
+        r = self._session.get(
             "https://www.neunkirchen-siegerland.de/output/autocomplete.php",
             params=args,
             headers=header,
@@ -59,7 +65,7 @@ class Source:
             )
 
         args = {"ModID": 48, "call": "ical", "pois": ids[0][0], "kat": 1, "alarm": 0}
-        r = requests.get(
+        r = self._session.get(
             "https://www.neunkirchen-siegerland.de/output/options.php",
             params=args,
             headers=header,
@@ -70,6 +76,6 @@ class Source:
         dates = self._ics.convert(r.text)
 
         return [
-            Collection(date, waste_type, ICON_MAP.get(waste_type, "mdi:trash-can"))
+            Collection(date, waste_type, ICON_MAP.get(waste_type, Icons.GENERAL_WASTE))
             for date, waste_type in dates
         ]

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_neunkirchen_siegerland_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_neunkirchen_siegerland_de.py
@@ -24,8 +24,23 @@ ICON_MAP = {
     "Schadstoffsammlung": Icons.HAZARDOUS,
 }
 
-PARAM_TRANSLATIONS: dict = {}
-PARAM_DESCRIPTIONS: dict = {}
+PARAM_TRANSLATIONS = {
+    "en": {
+        "strasse": "Street",
+    },
+    "de": {
+        "strasse": "Straße",
+    },
+}
+
+PARAM_DESCRIPTIONS = {
+    "en": {
+        "strasse": "Partial or full street name as shown on the Neunkirchen Siegerland waste calendar (e.g. 'Waldstr' for 'Waldstraße').",
+    },
+    "de": {
+        "strasse": "Teil- oder vollständiger Straßenname wie im Abfallkalender Neunkirchen Siegerland (z.B. 'Waldstr' für 'Waldstraße').",
+    },
+}
 
 
 class Source:

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_neunkirchen_siegerland_de.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/source/abfall_neunkirchen_siegerland_de.py
@@ -10,6 +10,8 @@ TITLE = "Neunkirchen Siegerland"
 DESCRIPTION = "Source for 'Abfallkalender Neunkirchen Siegerland'."
 URL = "https://www.neunkirchen-siegerland.de"
 COUNTRY = "de"
+AUTOCOMPLETE_URL = f"{URL}/output/autocomplete.php"
+CALENDAR_URL = f"{URL}/output/options.php"
 TEST_CASES = {"Waldstraße": {"strasse": "Waldstr"}}
 SOURCE_CODEOWNERS = ["@bbr111"]
 
@@ -59,7 +61,7 @@ class Source:
         }
         header = {"Referer": URL}
         r = self._session.get(
-            "https://www.neunkirchen-siegerland.de/output/autocomplete.php",
+            AUTOCOMPLETE_URL,
             params=args,
             headers=header,
             timeout=30,
@@ -81,7 +83,7 @@ class Source:
 
         args = {"ModID": 48, "call": "ical", "pois": ids[0][0], "kat": 1, "alarm": 0}
         r = self._session.get(
-            "https://www.neunkirchen-siegerland.de/output/options.php",
+            CALENDAR_URL,
             params=args,
             headers=header,
             timeout=30,


### PR DESCRIPTION
## Summary

Updates the Abfall Neunkirchen Siegerland source to use `curl_cffi` for Cloudflare bypass, adds missing metadata fields, improves parameter documentation, and fixes icon handling.

## Changes

- **Cloudflare bypass**: Replace standard `requests` with `curl_cffi.requests` and use a session with Chrome impersonation to handle Cloudflare protection
- **Metadata**: Add `COUNTRY = "de"` and `SOURCE_CODEOWNERS = ["@bbr111"]`
- **Documentation**: Add `PARAM_TRANSLATIONS` and `PARAM_DESCRIPTIONS` for bilingual (en/de) parameter labels and descriptions
- **Icon handling**: Replace hardcoded `"mdi:trash-can"` string with `Icons.GENERAL_WASTE` enum member (CI requirement)
- **Minor fixes**: Remove leading space from `DESCRIPTION`

## Type of change

- [x] Bug fix / source fix
- [x] Documentation update

## Checklist

- [x] `python -m pytest tests/test_source_components.py -q` passes
- [x] `python -m black` and `python -m isort --profile black` run on changed source files
- [x] No generated files in diff
- [x] Icon map uses canonical `Icons` enum (not raw `"mdi:..."` strings)
- [x] `COUNTRY` set to valid lowercase code (`"de"`)
- [x] `PARAM_TRANSLATIONS` and `PARAM_DESCRIPTIONS` use supported languages only (`en`, `de`)

https://claude.ai/code/session_0174hZqrCGEnE1w7sFp4Wv6M