### PR TITLE
Fix mypy type-annotation issues in service layer

### DIFF
--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/AppAbfallplusDe.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/AppAbfallplusDe.py
@@ -458,7 +458,7 @@ class AppAbfallplusDe:
         bezirk_id="",
         strasse_id=None,
         hnr_id=None,
-    ):
+    ) -> None:
         self._client = str(uuid.uuid4())
 
         self._app_id = app_id

--- a/custom_components/waste_collection_schedule/waste_collection_schedule/service/Samiljo_se_wastetype_searcher.py
+++ b/custom_components/waste_collection_schedule/waste_collection_schedule/service/Samiljo_se_wastetype_searcher.py
@@ -77,7 +77,7 @@ retry_codes = [
 ]
 
 
-NEW_NAME_MAP = {}
+NEW_NAME_MAP: dict[str, str] = {}
 
 
 def waste_searcher(arg1):  # sourcery skip: use-fstring-for-concatenation


### PR DESCRIPTION
## What

Resolves the mypy findings reported by the pre-commit hook:

- **`Samiljo_se_wastetype_searcher.py`** — `NEW_NAME_MAP = {}` could not be inferred (`[var-annotated]` error). Added explicit `dict[str, str]` annotation (keys/values are both strings, per the `NEW_NAME_MAP[waste] = new_type` assignment).
- **`AppAbfallplusDe.py`** — `__init__` was untyped, so mypy emitted the `[annotation-unchecked]` note for its body. Added `-> None` so the function counts as typed and the note disappears.

## Verification

```
pre-commit run mypy --all-files
mypy.....................................................................Passed
```

No behavioural changes — annotations only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4iPbJbeQffwpTkBoent7j)_